### PR TITLE
fix: Ensure the `keepArray` node parameter is taken into the account.

### DIFF
--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -5,8 +5,8 @@ type AST = JsonataASTNode;
 
 export function escapeString(name:string){
   if (
-    /\s/.test(name) 
-    || ["null", "false", "true"].includes(name) 
+    /\s/.test(name)
+    || ["null", "false", "true"].includes(name)
     || /^\d/.test(name)
     || !(/^[a-zA-Z()._]+$/.test(name))
   ) {
@@ -105,6 +105,7 @@ export default function serializer(node: AST): string {
   } else if (node.type === "unary") {
     if (node.value === "{" && node.type === "unary") {
       let o = node as ObjectUnaryNode;
+      const keepArrayValue = node.keepArray ? "[]" : ""
       return (
         node.value +
         "\n\t" +
@@ -114,7 +115,7 @@ export default function serializer(node: AST): string {
               serializer(set[0]) + ":" + serializer(set[1])
           )
           .join(",\n\t") +
-        "\n}"
+        "\n}"+keepArrayValue
       );
     } else if (node.value === "[") {
       let a = node as ArrayUnaryNode;

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,7 @@ export interface VariableNode extends Node {
 export interface PathNode extends Node {
   type: "path";
   steps: JsonataASTNode[];
+  keepSingletonArray?: boolean
 }
 
 export interface BlockNode extends Node {
@@ -88,6 +89,7 @@ export interface ObjectUnaryNode extends Node {
   type: "unary";
   value: "{";
   lhs: UnaryTuple[];
+  keepArray?: boolean;
 }
 
 export interface ArrayUnaryNode extends Node {

--- a/test/features/Serializer.feature
+++ b/test/features/Serializer.feature
@@ -63,5 +63,6 @@ Feature: AST Serializer
             | `foobar-1`      |
             | foo.bar.baz     |
             | foo.foo_bar     |
+            | foo.{bar:"baz"}[]     |
 
 

--- a/test/steps/steps.ts
+++ b/test/steps/steps.ts
@@ -43,7 +43,7 @@ function filterObject(obj: any, key: string) {
 
 Then("the ASTs should match", async function(this: World) {
   const one = filterClone(this.state.ast, "position");
-  const two = filterClone(this.state.ast, "position");
+  const two = filterClone(this.state.ast2, "position");
   expect(one).to.be.deep.equals(two);
 });
 


### PR DESCRIPTION
## Description

First of all, thank you for this library. It's very helpful!

When I was playing with the _expression_ to _AST_ conversion back and forth, I noticed that the `keepArray` properties on a given node are not considered during the conversion from _AST_ to a string _expression_.

## Reproduction

Given the _expression_

```text
foo.{bar: "baz"}[]
```

The produced _AST_ using jsonata v1.7 yields:

```json
{
  "type": "path",
  "steps": [
    { "value": "foo", "type": "name", "position": 3 },
    {
      "type": "unary",
      "value": "{",
      "position": 5,
      "lhs": [
        [
          { "type": "path", "steps": [{ "value": "bar", "type": "name", "position": 8 }] },
          { "value": "baz", "type": "string", "position": 15 }
        ]
      ],
      "keepArray": true
    }
  ],
  "keepSingletonArray": true
}
```

Now, if we serialize the above _AST_ back to an _expression_ form, the result is as follows:

```text
foo.{bar: "baz"}
```

As you can see, we are missing the `[]` at the end of the _expression_

## Uncertainty

I'm not sure what `keepSingletonArray` is responsible for. I would be grateful for any guidance regarding this property - mainly is my contribution correct in relation to the `keepSingletonArray` property as well?
